### PR TITLE
Enabling blank issues for experiments

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Xpublish-community show and tell
     url: https://github.com/xpublish-community/community/discussions/categories/show-and-tell


### PR DESCRIPTION
Simply switching from false to true such that `xpublish-experiment` repos can have issues written. @abkfenris 